### PR TITLE
Bug fixes Regexp class is specified

### DIFF
--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -35,9 +35,9 @@ class FilterOutput < Output
   def passRules (record)
     if @all == 'allow'
       @denies.each do |deny|
-        if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+        if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1]) unless record[deny[0]].nil?) or record[deny[0]] == deny[1]
           @allows.each do |allow|
-            if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+            if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1]) unless record[allow[0]].nil?) or record[allow[0]] == allow[1]
               return true
             end
           end
@@ -47,9 +47,9 @@ class FilterOutput < Output
       return true
     else
       @allows.each do |allow|
-        if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+        if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1]) unless record[allow[0]].nil?) or record[allow[0]] == allow[1]
           @denies.each do |deny|
-            if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+            if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1]) unless record[allow[0]].nil?) or record[deny[0]] == deny[1]
               return false
             end
           end

--- a/test/plugin/test_out_filter.rb
+++ b/test/plugin/test_out_filter.rb
@@ -154,6 +154,28 @@ class Filter < Test::Unit::TestCase
 
     d = create_driver(%[
       all deny
+      allow test: /Geck/
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 0, d.emits.length
+
+    d = create_driver(%[
+      all allow
+      deny test: /Geck/
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 6, d.emits.length
+
+    d = create_driver(%[
+      all deny
       allow agent: /Geck/
       add_prefix hoge
     ], 'test.input')


### PR DESCRIPTION
i wrote this tests

```
155     d = create_driver(%[
156       all deny
157       allow test: /Geck/
158     ], 'test.input')
159     d.run do
160       data.each do |dat|
161         d.emit dat
162       end
163     end
164     assert_equal 0, d.emits.length
165
166     d = create_driver(%[
167       all allow
168       deny test: /Geck/
169     ], 'test.input')
170     d.run do
171       data.each do |dat|
172         d.emit dat
173       end
174     end
175     assert_equal 6, d.emits.length
```

I'm getting errors at run time

```
$ rake test
  1) Error:
test_emit(Filter):
NoMethodError: undefined method `match' for nil:NilClass
```

See a sample of this blog
http://muddydixon.hatenablog.com/entry/2012/08/31/144853

For example, I'm getting errors this message

```
echo '{"key1":"key2"}' | fluent-cat test.list -p 9999
```

fluentd error message

```
2013-08-08 19:09:24 +0900 [error]: forward error: undefined method `match' for nil:NilClass
```
