### PR TITLE
fix: passRule causes error if record has not key in condition

### DIFF
--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -35,9 +35,9 @@ class FilterOutput < Output
   def passRules (record)
     if @all == 'allow'
       @denies.each do |deny|
-        if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+        if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
           @allows.each do |allow|
-            if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+            if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
               return true
             end
           end
@@ -47,9 +47,9 @@ class FilterOutput < Output
       return true
     else
       @allows.each do |allow|
-        if (allow[1].is_a? Regexp and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+        if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
           @denies.each do |deny|
-            if (deny[1].is_a? Regexp and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+            if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
               return false
             end
           end

--- a/test/plugin/test_out_filter.rb
+++ b/test/plugin/test_out_filter.rb
@@ -164,5 +164,34 @@ class Filter < Test::Unit::TestCase
     end
     assert_equal "hoge.test.input", d.emits[0][0]
 
+    data = [
+      {'message' => 'hoge', 'message2' => 'hoge2'},
+      {'message' => 'hoge3'},
+    ]
+
+    d = create_driver(%[
+      all deny
+      allow message2: /hoge2/
+    ], 'test.input')
+
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 1, d.emits.length
+
+    d = create_driver(%[
+      all allow
+      deny message2: /hoge2/
+    ], 'test.input')
+
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 1, d.emits.length
+
   end
 end


### PR DESCRIPTION
Hi, I fix the bug in method `passRules`.
`passRule` caused error if record has not key in condition.
Thanks.
