### PR TITLE
Add filter version of fluent-plugin-filter

### DIFF
--- a/fluent-plugin-filter.gemspec
+++ b/fluent-plugin-filter.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |gem|
   ]
   gem.add_development_dependency "rake"
   gem.add_development_dependency "fluentd"
+  gem.add_development_dependency "test-unit", "~> 3.1.0"
   gem.add_runtime_dependency "fluentd"
 end

--- a/lib/fluent/plugin/filter_filter.rb
+++ b/lib/fluent/plugin/filter_filter.rb
@@ -1,5 +1,8 @@
 module Fluent
 class FilterFilter < Filter
+  require 'fluent/plugin/filter_supplement'
+  include FilterSupplement
+
   Plugin.register_filter('filter', self)
 
   config_param :all, :string, :default => 'allow'
@@ -13,50 +16,6 @@ class FilterFilter < Filter
     super
     @allows = toMap(@allow)
     @denies = toMap(@deny)
-  end
-
-  def toMap (str)
-    str.split(/\s*,\s*/).map do|pair|
-      k, v = pair.split(/\s*:\s*/, 2)
-      if v =~ /^\d+$/
-        v = v.to_i
-      elsif v =~ /^[\d\.]+(e\d+)?$/
-        v = v.to_f
-      elsif v =~ /^\/(\\\/|[^\/])+\/$/
-        v = Regexp.new(v.gsub(/^\/|\/$/, ''))
-      else
-        v = v.gsub(/^[\"\']|[\"\']$/, '')
-      end
-      [k, v]
-    end
-  end
-
-  def passRules (record)
-    if @all == 'allow'
-      @denies.each do |deny|
-        if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
-          @allows.each do |allow|
-            if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
-              return true
-            end
-          end
-          return false
-        end
-      end
-      return true
-    else
-      @allows.each do |allow|
-        if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
-          @denies.each do |deny|
-            if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
-              return false
-            end
-          end
-          return true
-        end
-      end
-      return false
-    end
   end
 
   def filter(tag, time, record)

--- a/lib/fluent/plugin/filter_filter.rb
+++ b/lib/fluent/plugin/filter_filter.rb
@@ -1,0 +1,67 @@
+module Fluent
+class FilterFilter < Filter
+  Plugin.register_filter('filter', self)
+
+  config_param :all, :string, :default => 'allow'
+  config_param :allow, :string, :default => ''
+  config_param :deny, :string, :default => ''
+
+  attr_accessor :allows
+  attr_accessor :denies
+
+  def configure(conf)
+    super
+    @allows = toMap(@allow)
+    @denies = toMap(@deny)
+  end
+
+  def toMap (str)
+    str.split(/\s*,\s*/).map do|pair|
+      k, v = pair.split(/\s*:\s*/, 2)
+      if v =~ /^\d+$/
+        v = v.to_i
+      elsif v =~ /^[\d\.]+(e\d+)?$/
+        v = v.to_f
+      elsif v =~ /^\/(\\\/|[^\/])+\/$/
+        v = Regexp.new(v.gsub(/^\/|\/$/, ''))
+      else
+        v = v.gsub(/^[\"\']|[\"\']$/, '')
+      end
+      [k, v]
+    end
+  end
+
+  def passRules (record)
+    if @all == 'allow'
+      @denies.each do |deny|
+        if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+          @allows.each do |allow|
+            if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+              return true
+            end
+          end
+          return false
+        end
+      end
+      return true
+    else
+      @allows.each do |allow|
+        if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+          @denies.each do |deny|
+            if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+              return false
+            end
+          end
+          return true
+        end
+      end
+      return false
+    end
+  end
+
+  def filter(tag, time, record)
+    record if passRules(record)
+  end
+end
+
+end

--- a/lib/fluent/plugin/filter_supplement.rb
+++ b/lib/fluent/plugin/filter_supplement.rb
@@ -1,0 +1,47 @@
+module Fluent
+  module FilterSupplement
+    def toMap (str)
+      str.split(/\s*,\s*/).map do|pair|
+        k, v = pair.split(/\s*:\s*/, 2)
+        if v =~ /^\d+$/
+          v = v.to_i
+        elsif v =~ /^[\d\.]+(e\d+)?$/
+          v = v.to_f
+        elsif v =~ /^\/(\\\/|[^\/])+\/$/
+          v = Regexp.new(v.gsub(/^\/|\/$/, ''))
+        else
+          v = v.gsub(/^[\"\']|[\"\']$/, '')
+        end
+        [k, v]
+      end
+    end
+
+    def passRules (record)
+      if @all == 'allow'
+        @denies.each do |deny|
+          if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+            @allows.each do |allow|
+              if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+                return true
+              end
+            end
+            return false
+          end
+        end
+        return true
+      else
+        @allows.each do |allow|
+          if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
+            @denies.each do |deny|
+              if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
+                return false
+              end
+            end
+            return true
+          end
+        end
+        return false
+      end
+    end
+  end
+end

--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -1,5 +1,8 @@
 module Fluent
 class FilterOutput < Output
+  require 'fluent/plugin/filter_supplement'
+  include FilterSupplement
+
   Plugin.register_output('filter', self)
 
   config_param :all, :string, :default => 'allow'
@@ -14,50 +17,6 @@ class FilterOutput < Output
     super
     @allows = toMap(@allow)
     @denies = toMap(@deny)
-  end
-
-  def toMap (str)
-    str.split(/\s*,\s*/).map do|pair|
-      k, v = pair.split(/\s*:\s*/, 2)
-      if v =~ /^\d+$/
-        v = v.to_i
-      elsif v =~ /^[\d\.]+(e\d+)?$/
-        v = v.to_f
-      elsif v =~ /^\/(\\\/|[^\/])+\/$/
-        v = Regexp.new(v.gsub(/^\/|\/$/, ''))
-      else
-        v = v.gsub(/^[\"\']|[\"\']$/, '')
-      end
-      [k, v]
-    end
-  end
-
-  def passRules (record)
-    if @all == 'allow'
-      @denies.each do |deny|
-        if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
-          @allows.each do |allow|
-            if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
-              return true
-            end
-          end
-          return false
-        end
-      end
-      return true
-    else
-      @allows.each do |allow|
-        if (allow[1].is_a? Regexp and record.has_key?(allow[0]) and record[allow[0]].match(allow[1])) or record[allow[0]] == allow[1]
-          @denies.each do |deny|
-            if (deny[1].is_a? Regexp and record.has_key?(deny[0]) and record[deny[0]].match(deny[1])) or record[deny[0]] == deny[1]
-              return false
-            end
-          end
-          return true
-        end
-      end
-      return false
-    end
   end
 
   def emit(tag, es, chain)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,6 +23,7 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_filter'
+require 'fluent/plugin/filter_filter'
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -65,7 +65,7 @@ class TestFilterFilter < Test::Unit::TestCase
     assert_equal [], d.instance.denies
 
   end
-  def test_emit
+  def test_filter
     data = [
       {'status' => 200, 'agent' => 'IE', 'path' => '/users/1'},
       {'status' => 303, 'agent' => 'Gecko'},
@@ -78,10 +78,10 @@ class TestFilterFilter < Test::Unit::TestCase
     d = create_driver(CONFIG, 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 5, d.emits.length
+    assert_equal 5, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -89,10 +89,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -100,10 +100,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 4, d.emits.length
+    assert_equal 4, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -111,10 +111,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -122,10 +122,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -134,10 +134,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -145,10 +145,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 4, d.emits.length
+    assert_equal 4, d.filtered_as_array.length
 
     d = create_driver(%[
       all deny
@@ -156,10 +156,10 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal "test.input", d.emits[0][0]
+    assert_equal "test.input", d.filtered_as_array[0][0]
 
     d = create_driver(%[
       all deny
@@ -168,10 +168,10 @@ class TestFilterFilter < Test::Unit::TestCase
 
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.filtered_as_array.length
 
     data = [
       {'message' => 'hoge', 'message2' => 'hoge2'},
@@ -185,10 +185,10 @@ class TestFilterFilter < Test::Unit::TestCase
 
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 1, d.emits.length
+    assert_equal 1, d.filtered_as_array.length
 
     d = create_driver(%[
       all allow
@@ -197,10 +197,10 @@ class TestFilterFilter < Test::Unit::TestCase
 
     d.run do
       data.each do |dat|
-        d.emit dat
+        d.filter dat
       end
     end
-    assert_equal 1, d.emits.length
+    assert_equal 1, d.filtered_as_array.length
 
   end
 end

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -15,56 +15,40 @@ class TestFilterFilter < Test::Unit::TestCase
     Fluent::Test::FilterTestDriver.new(Fluent::FilterFilter, tag).configure(conf)
   end
 
-  def test_configure
-    # int value
-    d = create_driver %[
+  data("int value" => [{"allows" => [['status', 200]], "denies" => []},
+    %[
       all deny
       allow status: 200
-    ]
-    assert_equal [['status', 200]], d.instance.allows
-    assert_equal [], d.instance.denies
-
-    # float value
-    d = create_driver %[
+    ]],
+       "float value" => [{"allows" => [['status', 200.0]], "denies" => []},
+    %[
       all deny
       allow status: 200.0
-    ]
-    assert_equal [['status', 200.0]], d.instance.allows
-    assert_equal [], d.instance.denies
-
-    # text value
-    d = create_driver %[
+    ]],
+      "text value" => [{"allows" => [['status', '200']], "denies" => []},
+    %[
       all deny
-      allow status: "200"
-    ]
-    assert_equal [['status', '200']], d.instance.allows
-    assert_equal [], d.instance.denies
-
-    # text value
-    d = create_driver %[
+      allow status: '200'
+    ]],
+      "text value with URL" =>
+      [{"allows" => [['status', 'https://my.website.com/']], "denies" => []},
+    %[
       all deny
       allow status: "https://my.website.com/"
-    ]
-    assert_equal [['status', 'https://my.website.com/']], d.instance.allows
-    assert_equal [], d.instance.denies
-
-    # regexp value
-    d = create_driver %[
-      all deny
-      allow url: /hoge/
-    ]
-    assert_equal [['url', /hoge/]], d.instance.allows
-    assert_equal [], d.instance.denies
-
-    # regexp value with forward slashes
-    d = create_driver %[
+    ]],
+      "regexp value with forward slashes" =>
+      [{"allows" => [['url', Regexp.new("\\/users\\/\\d+")]], "denies" => []},
+    %[
       all deny
       allow url: /\\/users\\/\\d+/
-    ]
-    assert_equal [['url', Regexp.new("\\/users\\/\\d+")]], d.instance.allows
-    assert_equal [], d.instance.denies
-
+    ]])
+  def test_configure(data)
+    expected, target = data
+    d = create_driver target
+    assert_equal expected["allows"], d.instance.allows
+    assert_equal expected["denies"], d.instance.denies
   end
+
   def test_filter
     data = [
       {'status' => 200, 'agent' => 'IE', 'path' => '/users/1'},

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+require 'helper'
+
+class TestFilterFilter < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+  end
+
+  CONFIG = %[
+    all allow
+    deny status: 404
+  ]
+
+  def create_driver(conf = CONFIG, tag='test.input')
+    Fluent::Test::FilterTestDriver.new(Fluent::FilterFilter, tag).configure(conf)
+  end
+
+  def test_configure
+    # int value
+    d = create_driver %[
+      all deny
+      allow status: 200
+    ]
+    assert_equal [['status', 200]], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # float value
+    d = create_driver %[
+      all deny
+      allow status: 200.0
+    ]
+    assert_equal [['status', 200.0]], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # text value
+    d = create_driver %[
+      all deny
+      allow status: "200"
+    ]
+    assert_equal [['status', '200']], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # text value
+    d = create_driver %[
+      all deny
+      allow status: "https://my.website.com/"
+    ]
+    assert_equal [['status', 'https://my.website.com/']], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # regexp value
+    d = create_driver %[
+      all deny
+      allow url: /hoge/
+    ]
+    assert_equal [['url', /hoge/]], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # regexp value with forward slashes
+    d = create_driver %[
+      all deny
+      allow url: /\\/users\\/\\d+/
+    ]
+    assert_equal [['url', Regexp.new("\\/users\\/\\d+")]], d.instance.allows
+    assert_equal [], d.instance.denies
+
+  end
+  def test_emit
+    data = [
+      {'status' => 200, 'agent' => 'IE', 'path' => '/users/1'},
+      {'status' => 303, 'agent' => 'Gecko'},
+      {'status' => 200, 'agent' => 'IE', 'path' => '/users/2'},
+      {'status' => 401, 'agent' => 'Gecko'},
+      {'status' => 200, 'agent' => 'Gecka', 'path' => '/users/3'},
+      {'status' => 404, 'agent' => 'Gecko', 'path' => '/wrong'},
+    ]
+
+    d = create_driver(CONFIG, 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 5, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow status: 200
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 3, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow status: 200, status: 303
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 4, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow agent: Gecko
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 3, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow agent: "Gecko"
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 3, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow agent: "Gecko"
+      deny status: 200
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 3, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow agent: /Geck/
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 4, d.emits.length
+
+    d = create_driver(%[
+      all deny
+      allow agent: /Geck/
+    ], 'test.input')
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal "test.input", d.emits[0][0]
+
+    d = create_driver(%[
+      all deny
+      allow path: /\\/users\\/\\d+/
+    ], 'test.input')
+
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 3, d.emits.length
+
+    data = [
+      {'message' => 'hoge', 'message2' => 'hoge2'},
+      {'message' => 'hoge3'},
+    ]
+
+    d = create_driver(%[
+      all deny
+      allow message2: /hoge2/
+    ], 'test.input')
+
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 1, d.emits.length
+
+    d = create_driver(%[
+      all allow
+      deny message2: /hoge2/
+    ], 'test.input')
+
+    d.run do
+      data.each do |dat|
+        d.emit dat
+      end
+    end
+    assert_equal 1, d.emits.length
+
+  end
+end

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -50,7 +50,7 @@ class TestFilterFilter < Test::Unit::TestCase
   end
 
   def test_filter
-    data = [
+    inputs = [
       {'status' => 200, 'agent' => 'IE', 'path' => '/users/1'},
       {'status' => 303, 'agent' => 'Gecko'},
       {'status' => 200, 'agent' => 'IE', 'path' => '/users/2'},
@@ -61,7 +61,7 @@ class TestFilterFilter < Test::Unit::TestCase
 
     d = create_driver(CONFIG, 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -72,7 +72,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow status: 200
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -83,7 +83,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow status: 200, status: 303
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -94,7 +94,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow agent: Gecko
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -105,7 +105,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow agent: "Gecko"
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -117,7 +117,7 @@ class TestFilterFilter < Test::Unit::TestCase
       deny status: 200
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -128,7 +128,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow agent: /Geck/
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -139,7 +139,7 @@ class TestFilterFilter < Test::Unit::TestCase
       allow agent: /Geck/
     ], 'test.input')
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -151,13 +151,13 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
 
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
     assert_equal 3, d.filtered_as_array.length
 
-    data = [
+    inputs = [
       {'message' => 'hoge', 'message2' => 'hoge2'},
       {'message' => 'hoge3'},
     ]
@@ -168,7 +168,7 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
 
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end
@@ -180,7 +180,7 @@ class TestFilterFilter < Test::Unit::TestCase
     ], 'test.input')
 
     d.run do
-      data.each do |dat|
+      inputs.each do |dat|
         d.filter dat
       end
     end


### PR DESCRIPTION
Hi!

Thanks for providing great fluentd plugin!!
I think this plugin is one of the suitable case to provide filter plugin which is introduced since Fluentd v0.12.
I added filter version of `fluent-plugin-filter`.
In more detail, please refer to the official Fluentd.org document: http://docs.fluentd.org/articles/filter-plugin-overview.

And I've found that original output type fluent-plugin-filter testing code contains potential anti-pettern unit  testing.

More concretely, when using one by one assertions in tests, if one of the assertion is failed, after assertion is *nothing to be executed*. This makes hard to find out potential unit testing problem.
In contrast, data driven tests will be translated to individual test case per data by unit-test framework.
When using this unit testing way, once one of the test case will be failed, other test cases will be certainly executed.
In conclusion, data driven testing is more suitable than one by one assertions testing for this plugin testing code.

Enjoy fluentd plugin development with Ruby 2.2 and new filter plugin functionality.

Cheers!