### PR TITLE
Change from Engine.emit to router.emit

### DIFF
--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -25,7 +25,7 @@ class FilterOutput < Output
     end
     es.each do |time, record|
       next unless passRules(record)
-      Engine.emit(tag, time, record)
+      router.emit(tag, time, record)
     end
     chain.next
   end


### PR DESCRIPTION
Hi!

Please check the pull request.
Not use Engine.emit.

> use router.emit to emit events into Fluentd instead of Engine.emit

In more detail, please refer to the official Fluentd.org document:  http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12
