### PR TITLE
Use router.emit instead of Engine.emit to support fluentd  v0.14

### DIFF
--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -19,13 +19,18 @@ class FilterOutput < Output
     @denies = toMap(@deny)
   end
 
+  # Define `router` method of v0.12 to support v0.10 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Fluent::Engine }
+  end
+
   def emit(tag, es, chain)
     if @add_prefix
       tag = @add_prefix + '.' + tag
     end
     es.each do |time, record|
       next unless passRules(record)
-      Engine.emit(tag, time, record)
+      router.emit(tag, time, record)
     end
     chain.next
   end


### PR DESCRIPTION
With v0.14, Engine.emit was completely dropped. 

- http://www.fluentd.org/blog/fluentd-v0.14.0-has-been-released

```
Error: test_emit(Filter): RuntimeError: BUG: use router.emit instead of Engine.emit
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/engine.rb:132:in `emit'
/tmp/dev/ruby/fluent-plugin-filter/lib/fluent/plugin/out_filter.rb:28:in `block in emit'
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/event.rb:107:in `call'
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/event.rb:107:in `each'
/tmp/dev/ruby/fluent-plugin-filter/lib/fluent/plugin/out_filter.rb:26:in `emit'
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/compat/output.rb:162:in `process'
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/plugin/output.rb:695:in `emit_sync'
/tmp/dev/ruby/fluent-plugin-filter/.bundle/ruby/2.3.0/gems/fluentd-0.14.9/lib/fluent/test/output_test.rb:46:in `emit'
/tmp/dev/ruby/fluent-plugin-filter/test/plugin/test_out_filter.rb:91:in `block (2 levels) in test_emit'
     88:     d = create_driver(CONFIG, 'test.input')
     89:     d.run do
     90:       data.each do |dat|
  => 91:         d.emit dat
     92:       end
     93:     end
     94:     assert_equal 5, d.emits.length

```