### PR TITLE
Introduce a delim config_param

### DIFF
--- a/lib/fluent/plugin/filter_filter.rb
+++ b/lib/fluent/plugin/filter_filter.rb
@@ -8,14 +8,15 @@ class FilterFilter < Filter
   config_param :all, :string, :default => 'allow'
   config_param :allow, :string, :default => ''
   config_param :deny, :string, :default => ''
+  config_param :delim, :string, :default => ','
 
   attr_accessor :allows
   attr_accessor :denies
 
   def configure(conf)
     super
-    @allows = toMap(@allow)
-    @denies = toMap(@deny)
+    @allows = toMap(@allow, @delim)
+    @denies = toMap(@deny, @delim)
   end
 
   def filter(tag, time, record)

--- a/lib/fluent/plugin/filter_util.rb
+++ b/lib/fluent/plugin/filter_util.rb
@@ -1,7 +1,7 @@
 module Fluent
   module FilterUtil
-    def toMap (str)
-      str.split(/\s*,\s*/).map do|pair|
+    def toMap (str, delim)
+      str.split(/\s*#{delim}\s*/).map do|pair|
         k, v = pair.split(/\s*:\s*/, 2)
         if v =~ /^\d+$/
           v = v.to_i

--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -9,14 +9,15 @@ class FilterOutput < Output
   config_param :allow, :string, :default => ''
   config_param :deny, :string, :default => ''
   config_param :add_prefix, :string, :default => 'filtered'
+  config_param :delim, :string, :default => ','
 
   attr_accessor :allows
   attr_accessor :denies
 
   def configure(conf)
     super
-    @allows = toMap(@allow)
-    @denies = toMap(@deny)
+    @allows = toMap(@allow, @delim)
+    @denies = toMap(@deny, @delim)
   end
 
   def emit(tag, es, chain)

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -41,7 +41,21 @@ class TestFilterFilter < Test::Unit::TestCase
     %[
       all deny
       allow url: /\\/users\\/\\d+/
-    ]])
+    ]],
+      "test values" =>
+      [{"allows" => [['message', 'CRIT'], ['message', 'WARN']], "denies" => []},
+    %[
+      all deny
+      allow message: 'CRIT', message: 'WARN'
+    ]],
+      "test values with comma" =>
+      [{"allows" => [['message', 'CRIT,'], ['message', 'WARN']], "denies" => []},
+    %[
+      all deny
+      allow message: 'CRIT,' % message: 'WARN'
+      delim %
+    ]],
+      )
   def test_configure(data)
     expected, target = data
     d = create_driver target

--- a/test/plugin/test_out_filter.rb
+++ b/test/plugin/test_out_filter.rb
@@ -74,6 +74,23 @@ class Filter < Test::Unit::TestCase
     assert_equal [['url', Regexp.new("\\/users\\/\\d+")]], d.instance.allows
     assert_equal [], d.instance.denies
 
+    # text values
+    d = create_driver %[
+      all deny
+      allow message: 'CRIT', message: 'WARN'
+    ]
+    assert_equal [['message', 'CRIT'], ['message', 'WARN']], d.instance.allows
+    assert_equal [], d.instance.denies
+
+    # test values with comma
+    d = create_driver %[
+      all deny
+      allow message: 'CRIT,' % message: 'WARN'
+      delim %
+    ]
+    assert_equal [['message', 'CRIT,'], ['message', 'WARN']], d.instance.allows
+    assert_equal [], d.instance.denies
+
   end
   def test_emit
     data = [


### PR DESCRIPTION
When I try matching a string containing a comma, this plugin fails at compile.

- ex. `allow message: 'CRIT, hogehoge', message: 'WARN '`

```
# compile error log
2016-12-14 22:13:39 +0900 [error]: fluent/supervisor.rb:364:rescue in main_process: unexpected error error="undefined method `gsub' for nil:NilClass"
  2016-12-14 22:13:39 +0900 [error]: fluent/supervisor.rb:324:fork: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-filter-0.0.3/lib/fluent/plugin/out_filter.rb:29:in `block in toMap'
  2016-12-14 22:13:39 +0900 [error]: fluent/supervisor.rb:324:fork: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-filter-0.0.3/lib/fluent/plugin/out_filter.rb:20:in `map'
  2016-12-14 22:13:39 +0900 [error]: fluent/supervisor.rb:324:fork: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-filter-0.0.3/lib/fluent/plugin/out_filter.rb:20:in `toMap'
  2016-12-14 22:13:39 +0900 [error]: fluent/supervisor.rb:324:fork: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-filter-0.0.3/lib/fluent/plugin/out_filter.rb:16:in `configure'
```

An optional delimiter like '%' solves this issue.