### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 rvm:
   - 2.1
   - 2.2
+  - 2.3.4
+  - 2.4.1
 gemfile:
   - Gemfile

--- a/fluent-plugin-filter.gemspec
+++ b/fluent-plugin-filter.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   ]
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit", "~> 3.1.0"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
 end

--- a/lib/fluent/plugin/filter_filter.rb
+++ b/lib/fluent/plugin/filter_filter.rb
@@ -1,9 +1,10 @@
-module Fluent
+require 'fluent/plugin/filter_util'
+require 'fluent/plugin/filter'
+module Fluent::Plugin
 class FilterFilter < Filter
-  require 'fluent/plugin/filter_util'
   include FilterUtil
 
-  Plugin.register_filter('filter', self)
+  Fluent::Plugin.register_filter('filter', self)
 
   config_param :all, :string, :default => 'allow'
   config_param :allow, :string, :default => ''

--- a/lib/fluent/plugin/filter_util.rb
+++ b/lib/fluent/plugin/filter_util.rb
@@ -1,4 +1,4 @@
-module Fluent
+module Fluent::Plugin
   module FilterUtil
     def toMap (str, delim)
       str.split(/\s*#{delim}\s*/).map do|pair|

--- a/lib/fluent/plugin/out_filter.rb
+++ b/lib/fluent/plugin/out_filter.rb
@@ -1,9 +1,14 @@
-module Fluent
+require 'fluent/plugin/filter_util'
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
 class FilterOutput < Output
-  require 'fluent/plugin/filter_util'
+
+  helpers :event_emitter
+
   include FilterUtil
 
-  Plugin.register_output('filter', self)
+  Fluent::Plugin.register_output('filter', self)
 
   config_param :all, :string, :default => 'allow'
   config_param :allow, :string, :default => ''
@@ -25,7 +30,7 @@ class FilterOutput < Output
     define_method("router") { Fluent::Engine }
   end
 
-  def emit(tag, es, chain)
+  def process(tag, es)
     if @add_prefix
       tag = @add_prefix + '.' + tag
     end
@@ -33,7 +38,6 @@ class FilterOutput < Output
       next unless passRules(record)
       router.emit(tag, time, record)
     end
-    chain.next
   end
 end
 

--- a/test/plugin/test_filter_filter.rb
+++ b/test/plugin/test_filter_filter.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'helper'
+require 'fluent/test/driver/filter'
 
 class TestFilterFilter < Test::Unit::TestCase
   def setup
@@ -11,8 +12,8 @@ class TestFilterFilter < Test::Unit::TestCase
     deny status: 404
   ]
 
-  def create_driver(conf = CONFIG, tag='test.input')
-    Fluent::Test::FilterTestDriver.new(Fluent::FilterFilter, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Filter.new(Fluent::Plugin::FilterFilter).configure(conf)
   end
 
   data("int value" => [{"allows" => [['status', 200]], "denies" => []},
@@ -104,13 +105,13 @@ class TestFilterFilter < Test::Unit::TestCase
       {'status' => 200, 'agent' => 'Gecka', 'path' => '/users/3'},
       {'status' => 404, 'agent' => 'Gecko', 'path' => '/wrong'},
     ]
-    d = create_driver(target, 'test.input')
-    d.run do
+    d = create_driver(target)
+    d.run(default_tag: 'test') do
       inputs.each do |dat|
-        d.filter dat
+        d.feed dat
       end
     end
-    assert_equal expected, d.filtered_as_array.length
+    assert_equal expected, d.filtered.map{|e| e.last}.length
   end
 
   data("allow message2" => [1,
@@ -129,12 +130,12 @@ class TestFilterFilter < Test::Unit::TestCase
       {'message' => 'hoge', 'message2' => 'hoge2'},
       {'message' => 'hoge3'},
     ]
-    d = create_driver(target, 'test.input')
-    d.run do
+    d = create_driver(target)
+    d.run(default_tag: 'test.input') do
       inputs.each do |dat|
-        d.filter dat
+        d.feed dat
       end
     end
-    assert_equal expected, d.filtered_as_array.length
+    assert_equal expected, d.filtered.map{|e| e.last}.length
   end
 end

--- a/test/plugin/test_out_filter.rb
+++ b/test/plugin/test_out_filter.rb
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 require 'helper'
+require 'fluent/test/driver/output'
 
 class Filter < Test::Unit::TestCase
   def setup
@@ -11,8 +12,8 @@ class Filter < Test::Unit::TestCase
     deny status: 404
   ]
 
-  def create_driver(conf = CONFIG, tag='test.input')
-    Fluent::Test::OutputTestDriver.new(Fluent::FilterOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::FilterOutput).configure(conf)
   end
 
   def test_configure
@@ -102,104 +103,104 @@ class Filter < Test::Unit::TestCase
       {'status' => 404, 'agent' => 'Gecko', 'path' => '/wrong'},
     ]
 
-    d = create_driver(CONFIG, 'test.input')
-    d.run do
+    d = create_driver(CONFIG)
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 5, d.emits.length
+    assert_equal 5, d.events.length
 
     d = create_driver(%[
       all deny
       allow status: 200
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.events.length
 
     d = create_driver(%[
       all deny
       allow status: 200, status: 303
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 4, d.emits.length
+    assert_equal 4, d.events.length
 
     d = create_driver(%[
       all deny
       allow agent: Gecko
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.events.length
 
     d = create_driver(%[
       all deny
       allow agent: "Gecko"
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.events.length
 
     d = create_driver(%[
       all deny
       allow agent: "Gecko"
       deny status: 200
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.events.length
 
     d = create_driver(%[
       all deny
       allow agent: /Geck/
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 4, d.emits.length
+    assert_equal 4, d.events.length
 
     d = create_driver(%[
       all deny
       allow agent: /Geck/
       add_prefix hoge
-    ], 'test.input')
-    d.run do
+    ])
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal "hoge.test.input", d.emits[0][0]
+    assert_equal "hoge.test.input", d.events[0][0]
 
     d = create_driver(%[
       all deny
       allow path: /\\/users\\/\\d+/
-    ], 'test.input')
+    ])
 
-    d.run do
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 3, d.emits.length
+    assert_equal 3, d.events.length
 
     data = [
       {'message' => 'hoge', 'message2' => 'hoge2'},
@@ -209,26 +210,26 @@ class Filter < Test::Unit::TestCase
     d = create_driver(%[
       all deny
       allow message2: /hoge2/
-    ], 'test.input')
+    ])
 
-    d.run do
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 1, d.emits.length
+    assert_equal 1, d.events.length
 
     d = create_driver(%[
       all allow
       deny message2: /hoge2/
-    ], 'test.input')
+    ])
 
-    d.run do
+    d.run(default_tag: 'test.input') do
       data.each do |dat|
-        d.emit dat
+        d.feed dat
       end
     end
-    assert_equal 1, d.emits.length
+    assert_equal 1, d.events.length
 
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance, 